### PR TITLE
Use PostCSS plugin API.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,16 @@
-var list = require('postcss/lib/list');
+var postcss = require('postcss');
+var space   = postcss.list.space;
 
-module.exports = function (css) {
-    css.eachDecl('size', function (decl, i) {
-        var sizes = list.space(decl.value);
-        if ( sizes.length == 1 ) sizes[1] = sizes[0];
+module.exports = postcss.plugin('postcss-size', function () {
+    return function (css) {
+        css.eachDecl('size', function (decl, i) {
+            var sizes = space(decl.value);
+            if ( sizes.length == 1 ) sizes[1] = sizes[0];
 
-        decl.cloneBefore({ prop: 'width',  value: sizes[0] });
-        decl.cloneBefore({ prop: 'height', value: sizes[1] });
+            decl.cloneBefore({ prop: 'width',  value: sizes[0] });
+            decl.cloneBefore({ prop: 'height', value: sizes[1] });
 
-        decl.removeSelf();
-    });
-};
+            decl.removeSelf();
+        });
+    };
+});

--- a/package.json
+++ b/package.json
@@ -10,15 +10,15 @@
         "url":  "https://github.com/postcss/postcss-size.git"
     },
     "dependencies": {
-        "postcss": "^4.0.3"
+        "postcss": "^4.1.5"
     },
     "devDependencies": {
-        "jshint-stylish": "1.0.0",
-        "gulp-jshint":    "1.9.2",
-        "gulp-mocha":     "2.0.0",
-        "mocha":          "2.1.0",
-        "chai":           "1.10.0",
-        "gulp":           "3.8.10"
+        "jshint-stylish": "1.0.1",
+        "gulp-jshint":    "1.10.0",
+        "gulp-mocha":     "2.0.1",
+        "mocha":          "2.2.4",
+        "chai":           "2.2.0",
+        "gulp":           "3.8.11"
     },
     "scripts": {
         "test": "gulp"


### PR DESCRIPTION
Bumped dependencies, now uses the plugin API. I noticed also the changelog has the wrong extension, but I didn't fix it in this patch.
